### PR TITLE
Prevent building error with rabbit-tea template.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,11 @@ export default function rabbitTEA(mainPackagePath?: string): Plugin {
     const result = spawnSync('moon', ['build', '--target', 'js', isBuild ? '--release' : '--debug']);
     if (result.status == 0) {
       cpSync(outputJsPath(), tempJsPath);
-      cpSync(outputSourceMapPath(), tempSourceMapPath);
+      // Only copy source map if it exists (release builds don't generate source maps)
+      const sourceMapPath = outputSourceMapPath();
+      if (fs.existsSync(sourceMapPath)) {
+        cpSync(sourceMapPath, tempSourceMapPath);
+      }
       hasError = false;
     } else {
       hasError = true;


### PR DESCRIPTION
When I clone [rabbit-tea-template](https://github.com/moonbit-community/rabbit-tea-template) and execute `npm run build` locally, I get this error.

```
> build
> vite build

vite v5.4.20 building for production...
buildStart error Error: ENOENT: no such file or directory, lstat 'target/js/release/build/main/main.js.map'
    at cpSyncFn (node:internal/fs/cp/cp-sync:56:13)
    at cpSync (node:fs:3128:3)
    at runMoonbitBuild (file:///Users/AntiSatori/ghq/github.com/dowdiness/language-labo/node_modules/rabbit-tea-vite/dist/index.js:85:13)
    at Object.buildStart (file:///Users/AntiSatori/ghq/github.com/dowdiness/language-labo/node_modules/rabbit-tea-vite/dist/index.js:117:17)
    at file:///Users/AntiSatori/ghq/github.com/dowdiness/language-labo/node_modules/rollup/dist/es/shared/node-entry.js:22426:40
    at async Promise.all (index 5)
    at async PluginDriver.hookParallel (file:///Users/AntiSatori/ghq/github.com/dowdiness/language-labo/node_modules/rollup/dist/es/shared/node-entry.js:22336:9)
    at async file:///Users/AntiSatori/ghq/github.com/dowdiness/language-labo/node_modules/rollup/dist/es/shared/node-entry.js:23308:13
    at async catchUnfinishedHookActions (file:///Users/AntiSatori/ghq/github.com/dowdiness/language-labo/node_modules/rollup/dist/es/shared/node-entry.js:22780:16)
    at async rollupInternal (file:///Users/AntiSatori/ghq/github.com/dowdiness/language-labo/node_modules/rollup/dist/es/shared/node-entry.js:23305:5) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'lstat',
  path: 'target/js/release/build/main/main.js.map'
}
✓ 4 modules transformed.
dist/index.html                  0.38 kB │ gzip:  0.27 kB
dist/assets/index-C8PjIXBC.css   6.88 kB │ gzip:  2.03 kB
dist/assets/index-CKFB0uoJ.js   35.08 kB │ gzip: 10.69 kB
✓ built in 554ms
```

Moonbit doesn't seem to be generating source maps for release builds. I've added a check to skip copying the source map if it doesn't exist. I'm not sure why it's happening, but this should work as a temporary fix until it's addressed in a future Moonbit or Vite update.
